### PR TITLE
fixes import of React and Component breaking in 0.25.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
-
-import React, {
-    Component,
+import React, {Component} from 'react';
+import {
     View,
     Platform
 } from 'react-native';


### PR DESCRIPTION
A breaking change in version 0.25.1 of react-native causes this component to no longer work. This pull request fixes the issue.

https://github.com/facebook/react-native/releases/tag/v0.25.1