### PR TITLE
add props.style api

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ class ExampleComponent extends Component {
 
 export default ExampleComponent;
 ```
+
+Provide custom styles to bar (applies only in iOS)
+```js
+<StatusBarPaddingIOS style={{backgroundColor: 'red'}}/>
+```

--- a/index.js
+++ b/index.js
@@ -2,4 +2,12 @@ import React from 'react';
 import {View, Platform} from 'react-native';
 import StatusBarSizeIOS from 'react-native-status-bar-size';
 
-export default () => <View style={{height: Platform.OS === 'ios' ? StatusBarSizeIOS.currentHeight : 0}}/>;
+export default props => (
+    Platform.OS === 'ios'
+        ?  <View
+            style={Object.assign({
+                height: StatusBarSizeIOS.currentHeight
+            }, props.style || {})}
+        />
+        : <View/>
+);


### PR DESCRIPTION
Hi!
Added ability to proxy some styles to padding view.
I got bad diff in `index.js` because of `^M` symbol (I removed it).

![image](https://user-images.githubusercontent.com/2204267/35096187-50e092c2-fc5c-11e7-9141-48dbe5be69e5.png)
